### PR TITLE
Split the experimental 1802, Added a Reload capability, changed toggles to set/unset pairs

### DIFF
--- a/dce/DataMenu.txt
+++ b/dce/DataMenu.txt
@@ -219,15 +219,16 @@ MENU CD4000 Series {
    }
   }
 MENU CDP1800 Series {
-  ITEM /docs/parts/cdp1800/CDP1852.txt  CDP1852 - 8-bit Input/Output port
-  ITEM /docs/parts/cdp1800/CDP1853.txt  CDP1853 - 1 of 8 decoder, active-high
-  ITEM /docs/parts/cdp1800/CDP1857.txt  CDP1857 - 4-bit bus driver/separator
-  ITEM /docs/parts/cdp1800/CDP1872.txt  CDP1872 - 8-bit Input Port
-  ITEM /docs/parts/cdp1800/CDP1874.txt  CDP1874 - 8-bit Input Port
-  ITEM /docs/parts/cdp1800/CDP1875.txt  CDP1875 - 8-bit Output Port
-  ITEM /docs/parts/cdp1800/CDP1881.txt  CDP1881 - 6-bit Memory Decoder
-  ITEM /docs/parts/cdp1800/CDP1882.txt  CDP1882 - 6-bit Memory Decoder
-  ITEM /docs/parts/cdp1800/CDP1883.txt  CDP1883 - 7-bit Memory Decoder
+  ITEM /docs/parts/cdp1800/CDP1802BC.txt CDP1802BC - Microprocessor
+  ITEM /docs/parts/cdp1800/CDP1852.txt   CDP1852 - 8-bit Input/Output port
+  ITEM /docs/parts/cdp1800/CDP1853.txt   CDP1853 - 1 of 8 decoder, active-high
+  ITEM /docs/parts/cdp1800/CDP1857.txt   CDP1857 - 4-bit bus driver/separator
+  ITEM /docs/parts/cdp1800/CDP1872.txt   CDP1872 - 8-bit Input Port
+  ITEM /docs/parts/cdp1800/CDP1874.txt   CDP1874 - 8-bit Input Port
+  ITEM /docs/parts/cdp1800/CDP1875.txt   CDP1875 - 8-bit Output Port
+  ITEM /docs/parts/cdp1800/CDP1881.txt   CDP1881 - 6-bit Memory Decoder
+  ITEM /docs/parts/cdp1800/CDP1882.txt   CDP1882 - 6-bit Memory Decoder
+  ITEM /docs/parts/cdp1800/CDP1883.txt   CDP1883 - 7-bit Memory Decoder
   }
 MENU PIC {
   ITEM /docs/parts/pic/24LC256.txt      24LC256 - 32Kx8 serial EEPROM

--- a/dce/MainMenu.java
+++ b/dce/MainMenu.java
@@ -32,6 +32,9 @@ public class MainMenu {
     m=new MenuItem("Load");
     m.addActionListener(view);
     menu.add(m);
+    m=new MenuItem("Reload");
+    m.addActionListener(view);
+    menu.add(m);
     menu.addSeparator();
     m=new MenuItem("Save");
     m.addActionListener(view);
@@ -152,13 +155,24 @@ public class MainMenu {
     b.add(m);
     menu.add(b);
     // Log Probes
-    m=new MenuItem("Log Probes");
+    // Background submenu
+    b=new Menu("Probes");
+    m=new MenuItem("Enable Logging");
     m.addActionListener(view);
-    menu.add(m);
+    b.add(m);
+    m=new MenuItem("Disable Logging");
+    m.addActionListener(view);
+    b.add(m);
+    menu.add(b);
     // Enable Debug Output
-    m=new MenuItem("Enable Debug");
+    b=new Menu("Debug");
+    m=new MenuItem("Start Debug");
     m.addActionListener(view);
-    menu.add(m);
+    b.add(m);
+    m=new MenuItem("Stop Debug");
+    m.addActionListener(view);
+    b.add(m);
+    menu.add(b);
 
     menuBar.add(menu);
 

--- a/dce/PartMenu.txt
+++ b/dce/PartMenu.txt
@@ -249,6 +249,7 @@ MENU CD4000 Series {
    }
   }
 MENU CDP1800 Series {
+  ITEM parts.cdp1800.CCDP1802BC CDP1802BC - Microprocessor
   ITEM parts.cdp1800.CCDP1852  CDP1852 - 8-bit Input/Output port
   ITEM parts.cdp1800.CCDP1853  CDP1853 - 1 of 8 decoder, active-high
   ITEM parts.cdp1800.CCDP1857  CDP1857 - 4-bit bus driver/separator

--- a/dce/Pinout.java
+++ b/dce/Pinout.java
@@ -7,6 +7,7 @@ public class Pinout extends Canvas {
   int numPins;
   Vector pinLabels;
   String name;
+  boolean flipped = false;
   public Pinout(String nm,int pins) {
     name=nm;
     setSize(200,400);
@@ -20,6 +21,14 @@ public class Pinout extends Canvas {
     }
   public void addLabel(String label) {
     pinLabels.addElement(label);
+    }
+  public void flip_diagram() {
+    flipped = !flipped;
+    // System.out.println ( "Flip Diagram = " + flipped );
+    repaint();
+    }
+  public void rotate_diagram() {
+    // System.out.println ( "Rotate Diagram (not implemented yet)" );
     }
   private void pintextxy(Graphics g,int x,int y,String txt) {
     char character;
@@ -74,21 +83,48 @@ public class Pinout extends Canvas {
     if (pins<13) diff=5; else diff=3;
     scale=15; diff=5;
     g.drawRect(x+70,y+scale,60,y+scale*(pins-1));
-    g.drawRect(x+95,y+scale,10,7);
+    if (flipped) {
+      g.fillOval(x+115,y+scale+4,8,8);
+    } else {
+      g.drawRect(x+95,y+scale,10,7);
+      g.fillOval(x+75,y+scale+4,8,8);
+    }
     for (i=1;i<=pins;i++) {
-      g.drawRect(x+60,y+scale*i+diff-1,10,8);
-      g.drawRect(x+130,y+scale*i+diff-1,10,8);
-      showNum(g,x+62,y+scale*i+diff+1,i);
-      showNum(g,x+132,y+scale*i+diff+1,(pins*2)-i+1);
+      if (flipped) {
+        g.drawRect(x+130,y+scale*i+diff-1,10,8);
+        g.drawRect(x+60,y+scale*i+diff-1,10,8);
+        showNum(g,x+132,y+scale*i+diff+1,i);
+        showNum(g,x+62,y+scale*i+diff+1,(pins*2)-i+1);
+      } else {
+        g.drawRect(x+60,y+scale*i+diff-1,10,8);
+        g.drawRect(x+130,y+scale*i+diff-1,10,8);
+        showNum(g,x+62,y+scale*i+diff+1,i);
+        showNum(g,x+132,y+scale*i+diff+1,(pins*2)-i+1);
+      }
       if (pinLabels.size()>=i) {
-        label=(String)pinLabels.elementAt(i-1);
+        if (flipped) {
+          label=(String)pinLabels.elementAt(pins*2-i);
+        } else {
+          label=(String)pinLabels.elementAt(i-1);
+        }
         pintextxy(g,x+59-8*label.length(),y+scale*i+diff,label);
         }
       if (pinLabels.size()>=(pins*2)-i) {
-        label=(String)pinLabels.elementAt(pins*2-i);
+        if (flipped) {
+          label=(String)pinLabels.elementAt(i-1);
+        } else {
+          label=(String)pinLabels.elementAt(pins*2-i);
+        }
         pintextxy(g,x+146,y+scale*i+diff,label);
         }
       }
     g.drawString(name,x+70,y+10);
+    if (flipped) {
+      g.drawString(name,x+70,y+10);
+      g.drawString("Bot",x+90,y+40);
+    } else {
+      g.drawString(name,x+70,y+10);
+      g.drawString("Top",x+88,y+40);
+    }
     }
   }

--- a/dce/View.java
+++ b/dce/View.java
@@ -66,47 +66,14 @@ public class View implements ActionListener,AdjustmentListener,WindowListener {
     FileDialog fileDialog;
     double st,et,cy;
     Vector parts;
-    if (e.getActionCommand().charAt(0)=='C') {
-      try {
-        Class c=Class.forName(e.getActionCommand().substring(1));
-        temp=(parts.Component)c.newInstance();
-        temp.init(window);
-        perfBoard.setDevice(temp);
-        Main.mode='C';
-        perfBoard.setCursor(new Cursor(Cursor.HAND_CURSOR));
-        } catch (ClassNotFoundException er) {
-          System.out.println("Class Not Found: " + e.getActionCommand());
-        } catch (IllegalAccessException er) {
-          System.out.println("Illegal Access");
-        } catch (InstantiationException er) {
-          System.out.println("Instantiation");
-        }
-      }
-    else if (e.getActionCommand().charAt(0)=='D') {
-       DataSheet d=new DataSheet(e.getActionCommand().substring(1,
-         e.getActionCommand().length()));
-       }
-    else if ((e.getActionCommand()=="Save")&&(Globals.current_file_name!=null)) {
-      board.saveFile(Globals.current_file_name);
-      }
-    else if ((e.getActionCommand()=="Save As...")||(e.getActionCommand()=="Save")) {
-      fileDialog=new FileDialog(window,"Save File",FileDialog.SAVE);
-      fileDialog.setVisible(true);
-      if (fileDialog.getFile()!=null) {
-        Globals.current_file_name = fileDialog.getFile();
-        board.saveFile(Globals.current_file_name);
-        window.setTitle("DCE: " + Globals.current_file_name);
-        }
-      }
-    else if ((e.getActionCommand()=="Reload")&&(Globals.current_file_name!=null)) {
-      board.loadFile(Globals.current_file_name);
+
+    if (e.getActionCommand()=="New") {
+      keyListener=null;
+      Main.mode='E';
+      board.clear();
       perfBoard.update(perfBoard.getGraphics());
-      parts=board.getParts();
-      for (i=0;i<parts.size();i++) {
-        temp=(parts.Component)parts.elementAt(i);
-        if (temp instanceof CKeyboard)
-          perfBoard.addKeyListener((KeyListener)temp);
-        }
+      Globals.current_file_name = null;
+      window.setTitle("DCE");
       }
     else if (e.getActionCommand()=="Load") {
       fileDialog=new FileDialog(window,"Load File",FileDialog.LOAD);
@@ -124,17 +91,27 @@ public class View implements ActionListener,AdjustmentListener,WindowListener {
             perfBoard.addKeyListener((KeyListener)temp);
           }
       }
-    else if (e.getActionCommand()=="New") {
-      keyListener=null;
-      Main.mode='E';
-      board.clear();
+    else if ((e.getActionCommand()=="Reload")&&(Globals.current_file_name!=null)) {
+      board.loadFile(Globals.current_file_name);
       perfBoard.update(perfBoard.getGraphics());
-      Globals.current_file_name = null;
-      window.setTitle("DCE");
+      parts=board.getParts();
+      for (i=0;i<parts.size();i++) {
+        temp=(parts.Component)parts.elementAt(i);
+        if (temp instanceof CKeyboard)
+          perfBoard.addKeyListener((KeyListener)temp);
+        }
       }
-    else if (e.getActionCommand()=="Exit") {
-      window.setVisible(false);
-      System.exit(0);
+    else if ((e.getActionCommand()=="Save")&&(Globals.current_file_name!=null)) {
+      board.saveFile(Globals.current_file_name);
+      }
+    else if ((e.getActionCommand()=="Save As...")||(e.getActionCommand()=="Save")) {
+      fileDialog=new FileDialog(window,"Save File",FileDialog.SAVE);
+      fileDialog.setVisible(true);
+      if (fileDialog.getFile()!=null) {
+        Globals.current_file_name = fileDialog.getFile();
+        board.saveFile(Globals.current_file_name);
+        window.setTitle("DCE: " + Globals.current_file_name);
+        }
       }
     else if (e.getActionCommand()=="Black") {
       perfBoard.setWireColor(Color.black);
@@ -194,6 +171,7 @@ public class View implements ActionListener,AdjustmentListener,WindowListener {
       }
       }
     else if (e.getActionCommand()=="Disable Logging") {
+      System.out.println ( "--- Probe Logging Disabled ---" );
       board.logProbes = false;
       }
     else if (e.getActionCommand()=="Start Debug") {
@@ -325,6 +303,30 @@ public class View implements ActionListener,AdjustmentListener,WindowListener {
         Main.mode='L';
         }
       }
+    else if (e.getActionCommand()=="Exit") {
+      window.setVisible(false);
+      System.exit(0);
+      }
+    else if (e.getActionCommand().charAt(0)=='C') {
+      try {
+        Class c=Class.forName(e.getActionCommand().substring(1));
+        temp=(parts.Component)c.newInstance();
+        temp.init(window);
+        perfBoard.setDevice(temp);
+        Main.mode='C';
+        perfBoard.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        } catch (ClassNotFoundException er) {
+          System.out.println("Class Not Found: " + e.getActionCommand());
+        } catch (IllegalAccessException er) {
+          System.out.println("Illegal Access");
+        } catch (InstantiationException er) {
+          System.out.println("Instantiation");
+        }
+      }
+    else if (e.getActionCommand().charAt(0)=='D') {
+       DataSheet d=new DataSheet(e.getActionCommand().substring(1,
+         e.getActionCommand().length()));
+       }
     }
   public void windowActivated(WindowEvent e) {
     }

--- a/dce/View.java
+++ b/dce/View.java
@@ -98,6 +98,16 @@ public class View implements ActionListener,AdjustmentListener,WindowListener {
         window.setTitle("DCE: " + Globals.current_file_name);
         }
       }
+    else if ((e.getActionCommand()=="Reload")&&(Globals.current_file_name!=null)) {
+      board.loadFile(Globals.current_file_name);
+      perfBoard.update(perfBoard.getGraphics());
+      parts=board.getParts();
+      for (i=0;i<parts.size();i++) {
+        temp=(parts.Component)parts.elementAt(i);
+        if (temp instanceof CKeyboard)
+          perfBoard.addKeyListener((KeyListener)temp);
+        }
+      }
     else if (e.getActionCommand()=="Load") {
       fileDialog=new FileDialog(window,"Load File",FileDialog.LOAD);
       fileDialog.setVisible(true);
@@ -174,25 +184,25 @@ public class View implements ActionListener,AdjustmentListener,WindowListener {
     else if (e.getActionCommand()=="dark Yellow") {
       perfBoard.setWireColor(Globals.darkYellow);
       }
-    else if (e.getActionCommand()=="Log Probes") {
-      board.logProbes = ! board.logProbes;
+    else if (e.getActionCommand()=="Enable Logging") {
+      board.logProbes = true;
       if (board.logProbes) {
-        System.out.println( "--- Logging Started ---" );
         for (int p=0; p<board.probes.size(); p++) {
           System.out.print( ((Probe)board.probes.elementAt(p)).name + " " );
         }
         System.out.println();
-      } else {
-        System.out.println( "--- Logging Ended ---" );
       }
       }
-    else if (e.getActionCommand()=="Enable Debug") {
-      Globals.debug_enabled = ! Globals.debug_enabled;
-      if (Globals.debug_enabled) {
-        System.out.println ( "--- Debug Output Enabled ---" );
-      } else {
-        System.out.println ( "--- Debug Output Disabled ---" );
+    else if (e.getActionCommand()=="Disable Logging") {
+      board.logProbes = false;
       }
+    else if (e.getActionCommand()=="Start Debug") {
+      Globals.debug_enabled = true;
+      System.out.println ( "--- Debug Output Enabled ---" );
+      }
+    else if (e.getActionCommand()=="Stop Debug") {
+      Globals.debug_enabled = false;
+      System.out.println ( "--- Debug Output Disabled ---" );
       }
     else if (e.getActionCommand()=="BG Normal") {
       perfBoard.setBGColor(new Color(189,183,107));

--- a/dialogs/DataSheet.java
+++ b/dialogs/DataSheet.java
@@ -10,6 +10,8 @@ public class DataSheet implements ActionListener,WindowListener {
   Frame window;
   Pinout pinout;
   Button exitButton;
+  Button flipButton;
+  Button rotateButton;
   TextArea text;
   public DataSheet(String name) {
     int ret=0;
@@ -26,19 +28,38 @@ public class DataSheet implements ActionListener,WindowListener {
     text.setSize(570,450);
     text.setLocation(201,25);
     text.setVisible(true);
+
     exitButton=new Button("Close");
     exitButton.setSize(50,20);
     exitButton.setLocation(1,25);
     exitButton.setVisible(true);
     exitButton.addActionListener(this);
+
+    flipButton=new Button("Flip");
+    flipButton.setSize(50,20);
+    flipButton.setLocation(50,25);
+    flipButton.setVisible(true);
+    flipButton.addActionListener(this);
+
+    /*
+    rotateButton=new Button("Rotate");
+    rotateButton.setSize(50,20);
+    rotateButton.setLocation(100,25);
+    rotateButton.setVisible(true);
+    rotateButton.addActionListener(this);
+    */
+
     ret=readFile(name);
     window.add(text);
     window.add(exitButton);
+    window.add(flipButton);
+    // window.add(rotateButton);
     window.setVisible(true);
     if (ret==0) {
       window.dispose();
       }
     }
+
   public int readFile(String name) {
     MyBufferedInputStream file;
     StringBuffer   buffer=new StringBuffer();
@@ -97,6 +118,12 @@ public class DataSheet implements ActionListener,WindowListener {
     if ("Close".equals(e.getActionCommand())) {
       window.dispose();
       }
+    if ("Flip".equals(e.getActionCommand())) {
+      pinout.flip_diagram();
+      }
+    //if ("Rotate".equals(e.getActionCommand())) {
+    //  pinout.rotate_diagram();
+    //  }
     }
   public void windowActivated(WindowEvent e) {
     }

--- a/parts/experimental/CCDP1802BCex.java
+++ b/parts/experimental/CCDP1802BCex.java
@@ -3,10 +3,9 @@ import parts.*;
 import shared.*;
 
 /**
-* This class/part aspires to be a clock-for-clock simulation
-* of a CDP1802BC microprocessor. At this time, it only
-* generates /XTAL, TPA, TPB, and SC0.
-*
+* <pre>
+* This class/part provides an interface between JDCE
+* and the Sim1802 class.
 * </pre>
 */
 
@@ -14,77 +13,9 @@ public class CCDP1802BCex extends Ic {
 
   Sim1802 sim;
 
-  // Define pin numbers for this part
-  /*
-  final int pCLK = 1;
-  final int pnWAIT = 2;
-  final int pnCLEAR = 3;
-  final int pQ = 4;
-  final int pSC1 = 5;
-  final int pSC0 = 6;
-  final int pnMRD = 7;
-  final int pDB7 = 8;
-  final int pDB6 = 9;
-  final int pDB5 = 10;
-  final int pDB4 = 11;
-  final int pDB3 = 12;
-  final int pDB2 = 13;
-  final int pDB1 = 14;
-  final int pDB0 = 15;
-  final int pVCC = 16;
-  final int pN2 = 17;
-  final int pN1 = 18;
-  final int pN0 = 19;
-  final int pVSS = 20;
-  final int pnEF4 = 21;
-  final int pnEF3 = 22;
-  final int pnEF2 = 23;
-  final int pnEF1 = 24;
-  final int pMA0 = 25;
-  final int pMA1 = 26;
-  final int pMA2 = 27;
-  final int pMA3 = 28;
-  final int pMA4 = 29;
-  final int pMA5 = 30;
-  final int pMA6 = 31;
-  final int pMA7 = 32;
-  final int pTPB = 33;
-  final int pTPA = 34;
-  final int pnMWR = 35;
-  final int pnINT = 36;
-  final int pnDMAOUT = 37;
-  final int pnDMAIN = 38;
-  final int pnXTAL = 39;
-  final int pVDD = 40;
-  final int nPins = 40;
-  */
-
-  // Define the output pins
-  final int outpins[] = {
-    Sim1802.pQ,
-    Sim1802.pSC1,
-    Sim1802.pSC0,
-    Sim1802.pnMRD,
-    Sim1802.pN2,
-    Sim1802.pN1,
-    Sim1802.pN0,
-    Sim1802.pMA0,
-    Sim1802.pMA1,
-    Sim1802.pMA2,
-    Sim1802.pMA3,
-    Sim1802.pMA4,
-    Sim1802.pMA5,
-    Sim1802.pMA6,
-    Sim1802.pMA7,
-    Sim1802.pTPB,
-    Sim1802.pTPA,
-    Sim1802.pnMWR,
-    Sim1802.pnXTAL
-  };
-
   int lastCLK = 0;
   boolean in_init = true;
-  int clk = 14;        // Currently counts half clocks, initialized for proper phasing (not currently counting init)
+  int clk = 14;   // Currently counts half clocks, initialized for proper phasing (not currently counting init)
 
   // Helper function for debugging
   void println ( String s ) {
@@ -115,7 +46,7 @@ public class CCDP1802BCex extends Ic {
   * </pre>
   */
   public int numPins() {
-    return 40;
+    return sim.num_pins;
   }
 
   /**
@@ -132,8 +63,8 @@ public class CCDP1802BCex extends Ic {
       }
     } else {
       // Check if this is an output pin and return 1 if it is.
-      for (int i=0; i<outpins.length; i++) {
-        if (pn == outpins[i]) {
+      for (int i=0; i<sim.outpins.length; i++) {
+        if (pn == sim.outpins[i]) {
           return 1;
         }
       }
@@ -153,53 +84,25 @@ public class CCDP1802BCex extends Ic {
     boolean rising_edge = false;
     boolean falling_edge = false;
 
+    if (Globals.debug_enabled) {
+      sim.enable_debug();
+    } else {
+      sim.disable_debug();
+    }
+
     // Check for a clock edge ... everything happens on a clock edge
     if ( (pin[sim.pCLK] != 0) && (lastCLK == 0) ) rising_edge = true;
     if ( (pin[sim.pCLK] == 0) && (lastCLK != 0) ) falling_edge = true;
-    lastCLK = pin[sim.pCLK];
-    for (int i=0; i<outpins.length; i++) {
-      if (pin[outpins[i]] == 2) {
-        pin[outpins[i]] = 0;
-      }
-    }
     if (rising_edge || falling_edge) {
-
-      if (rising_edge) {
-        // This is a rising clock edge
-        println ( "Rising Edge of clock " + clk );
-      } else if (falling_edge) {
-        // This is a falling clock edge
-        println ( "Falling Edge of clock " + clk );
+      for (int p=0; p<=sim.num_pins; p++) {
+        sim.pin[p] = pin[p];
       }
-
-      // Set TPA and TPB as needed
-      if        ((clk%16) == 1) {
-        pin[sim.pTPA] = 1;
-      } else if ((clk%16) == 3) {
-        pin[sim.pTPA] = 0;
-      } else if ((clk%16) == 12) {
-        pin[sim.pTPB] = 1;
-      } else if ((clk%16) == 14) {
-        pin[sim.pTPB] = 0;
+      sim.run_half_clock();
+      for (int p=0; p<=sim.num_pins; p++) {
+        pin[p] = sim.pin[p];
       }
-      // Toggle SC0 as needed
-      if ((clk%16) == 15) {
-        pin[sim.pSC0] = 1 - pin[sim.pSC0];
-      }
-
-      // Print the state if debugging is enabled
-      println ( "TPA=" + pin[sim.pTPA] + ", TPB=" + pin[sim.pTPB] + ", SC0=" + pin[sim.pSC0] );
-
-      // Advance the clock by half a cycle
-      clk = clk + 1;
     }
-
-    // Output to the nXTAL pin (opposite of CLK)
-    if (pin[sim.pCLK] == 0) {
-      pin[sim.pnXTAL] = 1;
-    } else {
-      pin[sim.pnXTAL] = 0;
-    }
+    lastCLK = pin[sim.pCLK];
 
     return 0;
   }

--- a/parts/experimental/Sim1802.java
+++ b/parts/experimental/Sim1802.java
@@ -1,27 +1,39 @@
+// Comment the following line to run as a stand alone class
+
 package parts.experimental;
-import parts.*;
-import shared.*;
+
+
+//import parts.*;
+//import shared.*;
 
 /**
+* <pre>
 * This class/part aspires to be a clock-for-clock simulation
-* of a CDP1802BC microprocessor. At this time, it only
+* of a CDP1802BC microprocessor. It can be built to run both
+* as a stand alone "main" program or as a module within the
+* JDCE simulation environment. At this time, it only
 * generates /XTAL, TPA, TPB, and SC0.
-*
 * </pre>
 */
 
+/*
 class pin {
   int value;
   public pin() {
     value = 0;
   }
 }
+*/
 
-public class Sim1802 extends Ic {
+public class Sim1802 {
 
-  pin p;
+  // Normally inherited from class IC:
+  public int pin[] = new int[100];
+  public String name = "";
+
 
   // Define pin numbers for this part
+  public final static int num_pins = 40;
   public final static int pCLK = 1;
   public final static int pnWAIT = 2;
   public final static int pnCLEAR = 3;
@@ -62,7 +74,6 @@ public class Sim1802 extends Ic {
   public final static int pnDMAIN = 38;
   public final static int pnXTAL = 39;
   public final static int pVDD = 40;
-  public final static int nPins = 40;
 
   // Define the output pins
   final int outpins[] = {pQ,pSC1,pSC0,pnMRD,pN2,pN1,pN0,pMA0,pMA1,pMA2,pMA3,pMA4,pMA5,pMA6,pMA7,pTPB,pTPA,pnMWR,pnXTAL};
@@ -71,12 +82,17 @@ public class Sim1802 extends Ic {
   boolean in_init = true;
   int clk = 14;        // Currently counts half clocks, initialized for proper phasing (not currently counting init)
 
+  boolean debug_enabled = false;
   // Helper function for debugging
   void println ( String s ) {
-    if (Globals.debug_enabled) {
+    //if (Globals.debug_enabled) {
+    if (debug_enabled) {
       System.out.println ( s );
     }
   }
+
+  void enable_debug() { debug_enabled = true; }
+  void disable_debug() { debug_enabled = false; }
 
   /**
   * <pre>
@@ -94,89 +110,38 @@ public class Sim1802 extends Ic {
   }
 
   /**
-  * <pre>
-  * This method is called by JDCE to find out how many pins this part has.
-  * </pre>
-  */
-  public int numPins() {
-    return 40;
-  }
-
-  /**
-  * This method is called by JDCE to figure out which pins are outputs.
-  * This method should return a 1 for output pins and 0 otherwise.
-  */
-  public int pinOut(int pn) {
-    // What does this section do? What is pin[42]? What are return codes 128 and 129?
-    if (pn>=pDB7 && pn<=pDB0) {
-      if (pin[42]==4) {
-        return 129;
-      } else {
-        return 128;
-      }
-    } else {
-      // Check if this is an output pin and return 1 if it is.
-      for (int i=0; i<outpins.length; i++) {
-        if (pn == outpins[i]) {
-          return 1;
-        }
-      }
-      // Otherwise return 0 (not an output pin)
-      return 0;
-    }
-  }
-
-  /**
   * This method is called by JDCE during simulation.
   * <p/>
   * Note that this method may be called many times during
   * a single clock cycle.
   */
-  public int run() {
+  public int run_half_clock() {
     // Run one "iteration" (half clock) of the 1802
-    boolean rising_edge = false;
-    boolean falling_edge = false;
-
-    // Check for a clock edge ... everything happens on a clock edge
-    if ( (pin[pCLK] != 0) && (lastCLK == 0) ) rising_edge = true;
-    if ( (pin[pCLK] == 0) && (lastCLK != 0) ) falling_edge = true;
-    lastCLK = pin[pCLK];
     for (int i=0; i<outpins.length; i++) {
       if (pin[outpins[i]] == 2) {
         pin[outpins[i]] = 0;
       }
     }
-    if (rising_edge || falling_edge) {
-
-      if (rising_edge) {
-        // This is a rising clock edge
-        println ( "Rising Edge of clock " + clk );
-      } else if (falling_edge) {
-        // This is a falling clock edge
-        println ( "Falling Edge of clock " + clk );
-      }
-
-      // Set TPA and TPB as needed
-      if        ((clk%16) == 1) {
-        pin[pTPA] = 1;
-      } else if ((clk%16) == 3) {
-        pin[pTPA] = 0;
-      } else if ((clk%16) == 12) {
-        pin[pTPB] = 1;
-      } else if ((clk%16) == 14) {
-        pin[pTPB] = 0;
-      }
-      // Toggle SC0 as needed
-      if ((clk%16) == 15) {
-        pin[pSC0] = 1 - pin[pSC0];
-      }
-
-      // Print the state if debugging is enabled
-      println ( "TPA=" + pin[pTPA] + ", TPB=" + pin[pTPB] + ", SC0=" + pin[pSC0] );
-
-      // Advance the clock by half a cycle
-      clk = clk + 1;
+    // Set TPA and TPB as needed
+    if        ((clk%16) == 1) {
+      pin[pTPA] = 1;
+    } else if ((clk%16) == 3) {
+      pin[pTPA] = 0;
+    } else if ((clk%16) == 12) {
+      pin[pTPB] = 1;
+    } else if ((clk%16) == 14) {
+      pin[pTPB] = 0;
     }
+    // Toggle SC0 as needed
+    if ((clk%16) == 15) {
+      pin[pSC0] = 1 - pin[pSC0];
+    }
+
+    // Print the state if debugging is enabled
+    println ( "TPA=" + pin[pTPA] + ", TPB=" + pin[pTPB] + ", SC0=" + pin[pSC0] );
+
+    // Advance the clock by half a cycle
+    clk = clk + 1;
 
     // Output to the nXTAL pin (opposite of CLK)
     if (pin[pCLK] == 0) {
@@ -187,4 +152,14 @@ public class Sim1802 extends Ic {
 
     return 0;
   }
+
+  public static void main(String[] args) {
+    System.out.println ( "Running Sim1802 on its own." );
+    Sim1802 sim = new Sim1802();
+    sim.enable_debug();
+    for (int i=0; i<40; i++) {
+      sim.run_half_clock();
+    }
+  }
+
 }

--- a/parts/experimental/Sim1802.java
+++ b/parts/experimental/Sim1802.java
@@ -10,77 +10,62 @@ import shared.*;
 * </pre>
 */
 
-public class CCDP1802BCex extends Ic {
+class pin {
+  int value;
+  public pin() {
+    value = 0;
+  }
+}
 
-  Sim1802 sim;
+public class Sim1802 extends Ic {
+
+  pin p;
 
   // Define pin numbers for this part
-  /*
-  final int pCLK = 1;
-  final int pnWAIT = 2;
-  final int pnCLEAR = 3;
-  final int pQ = 4;
-  final int pSC1 = 5;
-  final int pSC0 = 6;
-  final int pnMRD = 7;
-  final int pDB7 = 8;
-  final int pDB6 = 9;
-  final int pDB5 = 10;
-  final int pDB4 = 11;
-  final int pDB3 = 12;
-  final int pDB2 = 13;
-  final int pDB1 = 14;
-  final int pDB0 = 15;
-  final int pVCC = 16;
-  final int pN2 = 17;
-  final int pN1 = 18;
-  final int pN0 = 19;
-  final int pVSS = 20;
-  final int pnEF4 = 21;
-  final int pnEF3 = 22;
-  final int pnEF2 = 23;
-  final int pnEF1 = 24;
-  final int pMA0 = 25;
-  final int pMA1 = 26;
-  final int pMA2 = 27;
-  final int pMA3 = 28;
-  final int pMA4 = 29;
-  final int pMA5 = 30;
-  final int pMA6 = 31;
-  final int pMA7 = 32;
-  final int pTPB = 33;
-  final int pTPA = 34;
-  final int pnMWR = 35;
-  final int pnINT = 36;
-  final int pnDMAOUT = 37;
-  final int pnDMAIN = 38;
-  final int pnXTAL = 39;
-  final int pVDD = 40;
-  final int nPins = 40;
-  */
+  public final static int pCLK = 1;
+  public final static int pnWAIT = 2;
+  public final static int pnCLEAR = 3;
+  public final static int pQ = 4;
+  public final static int pSC1 = 5;
+  public final static int pSC0 = 6;
+  public final static int pnMRD = 7;
+  public final static int pDB7 = 8;
+  public final static int pDB6 = 9;
+  public final static int pDB5 = 10;
+  public final static int pDB4 = 11;
+  public final static int pDB3 = 12;
+  public final static int pDB2 = 13;
+  public final static int pDB1 = 14;
+  public final static int pDB0 = 15;
+  public final static int pVCC = 16;
+  public final static int pN2 = 17;
+  public final static int pN1 = 18;
+  public final static int pN0 = 19;
+  public final static int pVSS = 20;
+  public final static int pnEF4 = 21;
+  public final static int pnEF3 = 22;
+  public final static int pnEF2 = 23;
+  public final static int pnEF1 = 24;
+  public final static int pMA0 = 25;
+  public final static int pMA1 = 26;
+  public final static int pMA2 = 27;
+  public final static int pMA3 = 28;
+  public final static int pMA4 = 29;
+  public final static int pMA5 = 30;
+  public final static int pMA6 = 31;
+  public final static int pMA7 = 32;
+  public final static int pTPB = 33;
+  public final static int pTPA = 34;
+  public final static int pnMWR = 35;
+  public final static int pnINT = 36;
+  public final static int pnDMAOUT = 37;
+  public final static int pnDMAIN = 38;
+  public final static int pnXTAL = 39;
+  public final static int pVDD = 40;
+  public final static int nPins = 40;
 
   // Define the output pins
-  final int outpins[] = {
-    Sim1802.pQ,
-    Sim1802.pSC1,
-    Sim1802.pSC0,
-    Sim1802.pnMRD,
-    Sim1802.pN2,
-    Sim1802.pN1,
-    Sim1802.pN0,
-    Sim1802.pMA0,
-    Sim1802.pMA1,
-    Sim1802.pMA2,
-    Sim1802.pMA3,
-    Sim1802.pMA4,
-    Sim1802.pMA5,
-    Sim1802.pMA6,
-    Sim1802.pMA7,
-    Sim1802.pTPB,
-    Sim1802.pTPA,
-    Sim1802.pnMWR,
-    Sim1802.pnXTAL
-  };
+  final int outpins[] = {pQ,pSC1,pSC0,pnMRD,pN2,pN1,pN0,pMA0,pMA1,pMA2,pMA3,pMA4,pMA5,pMA6,pMA7,pTPB,pTPA,pnMWR,pnXTAL};
 
   int lastCLK = 0;
   boolean in_init = true;
@@ -98,14 +83,13 @@ public class CCDP1802BCex extends Ic {
   * This method is called by JDCE to build this part.
   * </pre>
   */
-  public CCDP1802BCex() {
+  public Sim1802() {
     super();
-    sim = new Sim1802();
     name = new String("CDP1802BCex");
     pin  = new int[43]; // code below uses 42 ... [41]; // Arrays start at 0, but pins start at 1, so leave room
     lastCLK = 0;
-    pin[sim.pTPA] = 0;
-    pin[sim.pTPB] = 0;
+    pin[pTPA] = 0;
+    pin[pTPB] = 0;
     println ( "Created a " + name );
   }
 
@@ -124,7 +108,7 @@ public class CCDP1802BCex extends Ic {
   */
   public int pinOut(int pn) {
     // What does this section do? What is pin[42]? What are return codes 128 and 129?
-    if (pn>=sim.pDB7 && pn<=sim.pDB0) {
+    if (pn>=pDB7 && pn<=pDB0) {
       if (pin[42]==4) {
         return 129;
       } else {
@@ -154,9 +138,9 @@ public class CCDP1802BCex extends Ic {
     boolean falling_edge = false;
 
     // Check for a clock edge ... everything happens on a clock edge
-    if ( (pin[sim.pCLK] != 0) && (lastCLK == 0) ) rising_edge = true;
-    if ( (pin[sim.pCLK] == 0) && (lastCLK != 0) ) falling_edge = true;
-    lastCLK = pin[sim.pCLK];
+    if ( (pin[pCLK] != 0) && (lastCLK == 0) ) rising_edge = true;
+    if ( (pin[pCLK] == 0) && (lastCLK != 0) ) falling_edge = true;
+    lastCLK = pin[pCLK];
     for (int i=0; i<outpins.length; i++) {
       if (pin[outpins[i]] == 2) {
         pin[outpins[i]] = 0;
@@ -174,31 +158,31 @@ public class CCDP1802BCex extends Ic {
 
       // Set TPA and TPB as needed
       if        ((clk%16) == 1) {
-        pin[sim.pTPA] = 1;
+        pin[pTPA] = 1;
       } else if ((clk%16) == 3) {
-        pin[sim.pTPA] = 0;
+        pin[pTPA] = 0;
       } else if ((clk%16) == 12) {
-        pin[sim.pTPB] = 1;
+        pin[pTPB] = 1;
       } else if ((clk%16) == 14) {
-        pin[sim.pTPB] = 0;
+        pin[pTPB] = 0;
       }
       // Toggle SC0 as needed
       if ((clk%16) == 15) {
-        pin[sim.pSC0] = 1 - pin[sim.pSC0];
+        pin[pSC0] = 1 - pin[pSC0];
       }
 
       // Print the state if debugging is enabled
-      println ( "TPA=" + pin[sim.pTPA] + ", TPB=" + pin[sim.pTPB] + ", SC0=" + pin[sim.pSC0] );
+      println ( "TPA=" + pin[pTPA] + ", TPB=" + pin[pTPB] + ", SC0=" + pin[pSC0] );
 
       // Advance the clock by half a cycle
       clk = clk + 1;
     }
 
     // Output to the nXTAL pin (opposite of CLK)
-    if (pin[sim.pCLK] == 0) {
-      pin[sim.pnXTAL] = 1;
+    if (pin[pCLK] == 0) {
+      pin[pnXTAL] = 1;
     } else {
-      pin[sim.pnXTAL] = 0;
+      pin[pnXTAL] = 0;
     }
 
     return 0;


### PR DESCRIPTION
1. Created a new file named "Sim1802.java" file to hold the new 1802 code.
Sim1802.java will be a stand alone class that can be used either inside of JDCE or on its own (it has its own "main" function). It will still use the JDCE part named "CCDP1802BCex.java" as its interface to JDCE.

2. Added a "Reload" option and separate enable/disable for log and debug.
Sometimes it's handy to restart a simulation from a fresh load. This could have been done through the "Load" menu, but it requires picking the same file again. The new "Reload" command saves that step by simply reloading the file that's already loaded.

3. Replaced the toggling of logging and debugging with enable/disable options.
The current menu system uses MenuItems rather than check boxes, so there's no feedback as to what has been set. So toggling something might actually be enabling or disabling that feature. Adding two separate (enable/disable) menu items at least makes it clear what is being done (even if the previous state is unknown). This is really a quick fix until check boxe menu items can be properly coded.
