### PR TITLE
Added support for comments using a semicolon.  Added comments to the 1802_ROM_256_LED.ckt file.

### DIFF
--- a/circuits/1802_ROM_256_LED.ckt
+++ b/circuits/1802_ROM_256_LED.ckt
@@ -1,10 +1,18 @@
-6 44 24 24 0
-parts.cdp1800.CCDP1802BC 20 18
-parts.rom.C2708 28 32 Blink_Q
-parts.input.CClock 25 12
-parts.input.CPower 14 28
-parts.S7400.C74ls91 15 12
-parts.output.CLED_R 23 29
+; Header Line:  NumParts, NumWires, NumNets, NumProbes, NumLabels
+
+6 44 24 24 2
+
+; Parts List:   Package.Class, LocationX, LocationY, optional parameters
+
+parts.cdp1800.CCDP1802BC 20 18  ; 1802 located at grid point (20,18)
+parts.rom.C2708 28 32 Blink_Q   ; This is a ROM from file "Blink_Q.rom"
+parts.input.CClock 25 12        ; Clock chip
+parts.input.CPower 14 28        ; Power for the circuit
+parts.S7400.C74ls91 15 12       ; Shift register to provide delayed reset
+parts.output.CLED_R 23 29       ; Q Output LED
+
+; Wires List:   PartNum,PinNum, PartNum,PinNum, Color
+
 1 17 0 8 2
 0 9 1 16 2
 1 15 0 10 2
@@ -20,7 +28,7 @@ parts.output.CLED_R 23 29
 0 29 1 4 5
 1 3 0 30 5
 0 31 1 2 5
-2 1 0 1 5
+2 1 0 1 5    ; 1802's Pin1 (CLK) from Clock's Pin1
 3 2 1 19 1
 1 19 1 22 1
 1 22 1 23 1
@@ -39,7 +47,7 @@ parts.output.CLED_R 23 29
 0 3 4 13 3
 4 5 4 11 9
 3 1 1 24 9
-0 4 5 2 11
+0 4 5 2 11   ; 1802's Pin4 (Q) to LED's Pin2
 5 1 3 2 1
 0 36 0 37 9
 0 37 0 38 9
@@ -49,6 +57,9 @@ parts.output.CLED_R 23 29
 0 24 0 23 9
 0 23 0 22 9
 0 22 0 21 9
+
+; Probes List:  PartNum, PinNum, DisplayName
+
 0 3 /CLR
 0 1 CLK
 0 34 TPA
@@ -73,3 +84,8 @@ parts.output.CLED_R 23 29
 0 14 D1
 0 15 D0
 0 4 Q
+
+; Labels List:  LocationX, LocationY, Text
+
+12 36 Simple 1802
+12 38 with 256 byte ROM

--- a/dce/Board.java
+++ b/dce/Board.java
@@ -37,10 +37,32 @@ public class Board implements ActionListener {
     digiScope=l;
     }
   /**
+   * Return the next valid JDCE line ignoring comments and empty lines
+   */
+  public String readLine(BufferedReader file) throws IOException {
+    // System.out.println ( "Loading from \"" + file + "\"" );
+    String line;
+    int comment_start;
+    do {
+      line = file.readLine();
+      // System.out.println ( "  Line = \"" + line + "\"" );
+      if (line == null) {
+        throw ( new IOException() );
+      } else {
+        comment_start = line.indexOf(';');
+        if (comment_start >= 0) {
+          line = line.substring(0,comment_start);
+        }
+        line = line.trim();
+      }
+    } while ( line.length() <= 0 );
+    // System.out.println ( "Return \"" + line + "\"" );
+    return ( line );
+    }
+  /**
    * Clear all internal data
    * <p>
    * Clears the parts, wires, probes, and labels.
-   *
    */
   public void clear() {
     parts=null;
@@ -80,7 +102,7 @@ public class Board implements ActionListener {
       clear();
       file=new BufferedReader(new FileReader(fileName));
       buffer.setLength(0);
-      buffer.append(file.readLine());
+      buffer.append(this.readLine(file));
       buffer2.setLength(0);
       j=0;
       while (buffer.charAt(j)!=' ') buffer2.append(buffer.charAt(j++));
@@ -103,7 +125,7 @@ public class Board implements ActionListener {
       numLabels=(new Integer(buffer2.toString())).intValue();
       for (i=0;i<numParts;i++) {
         buffer.setLength(0);
-        buffer.append(file.readLine());
+        buffer.append(this.readLine(file));
         buffer2.setLength(0);
         j=0;
         while (buffer.charAt(j)!=' ') buffer2.append(buffer.charAt(j++));
@@ -117,7 +139,7 @@ public class Board implements ActionListener {
         }
       for (i=0;i<numWires;i++) {
         buffer.setLength(0);
-        buffer.append(file.readLine());
+        buffer.append(this.readLine(file));
         buffer2.setLength(0);
         j=0;
         while (buffer.charAt(j)!=' ') buffer2.append(buffer.charAt(j++));
@@ -146,7 +168,7 @@ public class Board implements ActionListener {
         }
       for (i=0;i<numProbes;i++) {
         buffer.setLength(0);
-        buffer.append(file.readLine());
+        buffer.append(this.readLine(file));
         buffer2.setLength(0);
         j=0;
         while (buffer.charAt(j)!=' ') buffer2.append(buffer.charAt(j++));
@@ -164,7 +186,7 @@ public class Board implements ActionListener {
         }
       for (i=0;i<numLabels;i++) {
         buffer.setLength(0);
-        buffer.append(file.readLine());
+        buffer.append(this.readLine(file));
         j=0;
         buffer2.setLength(0);
         while (buffer.charAt(j)!=' ') buffer2.append(buffer.charAt(j++));
@@ -184,6 +206,7 @@ public class Board implements ActionListener {
       file.close();
       } catch (IOException er) {
           System.out.println(er.toString());
+          System.out.println("Check format of file: \"" + fileName + "\"");
       } catch (ClassNotFoundException er) {
           System.out.println(er.toString());
       } catch (IllegalAccessException er) {


### PR DESCRIPTION
**Added support for semicolon comments (;...) in circuit files**

This change added a "readLine" method to the "Board" class to read a file and filter out comments (which are currently discarded). The new readLine method ("_this.readLine(file)_") replaces reading from the file method itself ("_file.readLine()_") in the _loadFile_ method. The new method filters each line to remove all text following and including a semicolon (;). It also removes any empty (whitespace only) lines. This allows the loadFile method to operate as it had in the past without any changes (other than calling _this.readLine_ instead of _file.readLine_).

Note that the use of the semicolon (;) for comments could be easily replaced with any other preferred character.

Also added comments to the example 1802_ROM_256_LED.ckt file.
